### PR TITLE
added ability to permanently remove params

### DIFF
--- a/src/ofxRemoteUIServer.cpp
+++ b/src/ofxRemoteUIServer.cpp
@@ -196,7 +196,7 @@ void ofxRemoteUIServer::setNewParamColor(int num){
 }
 
 
-void ofxRemoteUIServer::removeParamFromDB(const string & paramName){
+void ofxRemoteUIServer::removeParamFromDB(const string & paramName, bool permanently){
 
 	dataMutex.lock();
 	unordered_map<string, RemoteUIParam>::iterator it = params.find(paramName);
@@ -205,9 +205,11 @@ void ofxRemoteUIServer::removeParamFromDB(const string & paramName){
 
 		if(verbose_) RLOG_WARNING << "removing Param '" << paramName << "' from DB!" ;
 
-		//keep it in the removed struct
-		params_removed[paramName] = it->second;
-		orderedKeys_removed[orderedKeys_removed.size()] = paramName;
+        if(!permanently){
+            //keep it in the removed struct
+            params_removed[paramName] = it->second;
+            orderedKeys_removed[orderedKeys_removed.size()] = paramName;
+        }
 
 		params.erase(it);
 

--- a/src/ofxRemoteUIServer.h
+++ b/src/ofxRemoteUIServer.h
@@ -147,7 +147,7 @@ public:
 	void setClearXMLonSave(bool clear){clearXmlOnSaving = clear;} //this only affects xml v1 - not relevant nowadays
 	void setDirectoryPrefix(const std::string & _directoryPrefix); // set the optional directory prefix
 
-	void removeParamFromDB(const std::string & paramName);	//useful for params its value is kinda set and will not change,
+	void removeParamFromDB(const std::string & paramName, bool permanently = false);	//useful for params its value is kinda set and will not change,
 												//to load from xml and then remove from the list to
 												//avoid crowding the UI too much
 


### PR DESCRIPTION
this feature could be developed further to avoid caching problems when you only have temporary params that added and removed on the fly